### PR TITLE
Add auth_base_url config.

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -38,7 +38,8 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getAuthUrl($state)
     {
-        return $this->buildAuthUrlFromBase('https://open.weixin.qq.com/connect/oauth2/authorize', $state);
+        $base = config('services.weixin.auth_base_url', 'https://open.weixin.qq.com/connect/oauth2/authorize');
+        return $this->buildAuthUrlFromBase($base, $state);
     }
 
     /**


### PR DESCRIPTION
Since the original code hard code the auth url, but that url is used in wechat client. I add a new config parameter in `config\services.php`:

```
'weixin': [
    'client_id' => env('WEIXIN_KEY'),
    'client_secret' => env('WEIXIN_SECRET'),
    'redirect' => env('WEIXIN_REDIRECT_URI'),
    'auth_base_url' => env('WEIXIN_AUTH_BASE_URL', 'https://open.weixin.qq.com/connect/qrconnect')
]
```

Then the provider could show a qrcode, and user could login with wechat client. the code keeps the compatibility with the original one. I think the configuration should be written in the doc.
